### PR TITLE
tweaks for faster rendering (esp on integrated)

### DIFF
--- a/src/LyceumMuJoCoViz.jl
+++ b/src/LyceumMuJoCoViz.jl
@@ -268,7 +268,7 @@ function showhelp!(rect::MJCore.mjrRect, e::Engine)
     info1 = join(view(helparr, 1:i), '\n')
     info2 = join(view(helparr, min(l, (i + 1)):l), '\n')
 
-    mjr_overlay(MJCore.FONT_SHADOW, MJCore.GRID_TOPLEFT, rect, info1, info2, e.ui.con)
+    mjr_overlay(MJCore.FONT_NORMAL, MJCore.GRID_TOPLEFT, rect, info1, info2, e.ui.con)
     rect
 end
 
@@ -376,7 +376,7 @@ function runmode!(e::Engine)
         finally
             unlock(phys.lock)
         end
-        sleep(0.0001) # TODO adaptive sleep? Or a "shouldrender" flag
+        yield()
     end
     e
 end
@@ -399,7 +399,7 @@ function runrender!(engine::Engine)
                 islocked(lck) &&
                 current_task() === lck.locked_by && unlock(engine.phys.lock)
             end
-            sleep(0.0001)
+            yield()
         end
     finally
         engine.phys.shouldexit = true


### PR DESCRIPTION
Changed `sleep(0.0001)` -> `yield()` (sleep min time is 0.001 seconds so that ate up some time)

Also the main culprit looks like the mjr_overlay; when there's a lot of text to render it slows down. The rendering time is proportional to the text displayed. NORMAL text also is faster than SHADOW.

I didn't want to change the help notes, but closing the help tab (F1) makes the rendering go up to 60fps when paused and between 30 and 60 when the simulation is running.